### PR TITLE
RoleName (IE-66)

### DIFF
--- a/types/lambdaconfig.go
+++ b/types/lambdaconfig.go
@@ -2,6 +2,7 @@ package ie2datatypes
 
 type LambdaConfig struct {
 	Name         string `yaml:"name"`
+	RoleName     string `yaml:"rolename"`
 	Architecture string `yaml:"architecture"`
 	Runtime      string `yaml:"runtime"`
 	Handler      string `yaml:"handler"`


### PR DESCRIPTION
Motivation
---
It's time to support allowing lambda creators some more control over the role their lambda function should have assigned.

Modifications
---
- Added RoleName to type LambdaConfig