### PR TITLE
Type FileMetaData (IE-75)

### DIFF
--- a/types/filemetadata.go
+++ b/types/filemetadata.go
@@ -1,0 +1,16 @@
+package ie2datatypes
+
+type FileMetaData struct {
+	OGFileName string `json:"ogfilename"`
+	Synopsis   string `json:"synopsis"`
+	Authors    []struct {
+		FirstName string `json:"firstname"`
+		LastName  string `json:"lastname"`
+	} `json:"authors"`
+	ResearchAreas []struct {
+		ID   int32  `json:"id"`
+		Name string `json:"name"`
+	} `json:"researchareas"`
+	UploadedOn string `json:"uploadedon"`
+	IngestedOn string `json:"ingestedon"`
+}


### PR DESCRIPTION
Motivation
---
A new struct type for marshalling and unmarshalling json encoded metadata for fileuploads.

Modifications
---
- Added new FileMetaData type